### PR TITLE
Fix local video copy to write valid bytes

### DIFF
--- a/app/src/main/java/virtual/camera/app/view/setting/SettingFragment.java
+++ b/app/src/main/java/virtual/camera/app/view/setting/SettingFragment.java
@@ -129,8 +129,8 @@ public class SettingFragment extends BaseFragment {
             is = getActivitySafe().getContentResolver().openInputStream(uri);
             byte[] buffer = new byte[1024];
             int len = is.read(buffer);
-            while (len >= 0) {
-                fos.write(buffer);
+            while (len > 0) {
+                fos.write(buffer, 0, len);
                 len = is.read(buffer);
             }
             fos.flush();


### PR DESCRIPTION
## Summary
- ensure the local video copy loop continues only while data is read and writes only the valid bytes

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0e02758508325a56d12c027e276d5