### PR TITLE
Add build helper script and document APK generation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,28 @@
 # Contact Me
 andvipgroup@gmail.com
 
+# Building the APK
+
+The project can be packaged into a debug APK with the included Gradle
+wrapper. The helper script below pins the Java toolchain to JDK 17 so
+that the legacy Android Gradle Plugin used by this project runs
+successfully.
+
+1. Ensure you have internet connectivity the first time you build so
+   Gradle can download the Android Gradle Plugin and Kotlin compiler
+   dependencies.
+2. From the repository root execute:
+
+   ```bash
+   ./build_apk.sh
+   ```
+
+3. After a successful build the APK is generated at
+   `app/build/outputs/apk/debug/app-debug.apk`.
+
+> **Note:** The build will fail in fully offline environments because
+> the required Gradle plugins cannot be downloaded.
+
 # APK Download
 **Latest version : 3.0.0**
 

--- a/build_apk.sh
+++ b/build_apk.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+# Resolve the JDK 17 runtime shipped with the repository environment
+JAVA_HOME_DEFAULT="/root/.local/share/mise/installs/java/17.0.2"
+if [ -d "$JAVA_HOME_DEFAULT" ]; then
+  export JAVA_HOME="$JAVA_HOME_DEFAULT"
+  export PATH="$JAVA_HOME/bin:$PATH"
+fi
+
+echo "Using JAVA_HOME=$JAVA_HOME"
+./gradlew assembleDebug "$@"


### PR DESCRIPTION
## Summary
- add a helper script that pins JAVA_HOME to JDK 17 before running Gradle
- document the steps required to assemble the debug APK and note the network dependency

## Testing
- ./build_apk.sh *(fails: remote repositories return HTTP 403 because dependencies cannot be downloaded in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e173cf248325b6b54056b096425b