### PR TITLE
Fix user mapping for app installation

### DIFF
--- a/app/src/main/java/virtual/camera/app/view/main/MainActivity.kt
+++ b/app/src/main/java/virtual/camera/app/view/main/MainActivity.kt
@@ -94,7 +94,7 @@ class MainActivity : LoadingActivity() {
 
     private fun initFab() {
         viewBinding.fab.setOnClickListener {
-            val userId = viewBinding.viewPager.currentItem
+            val userId = fragmentList[viewBinding.viewPager.currentItem].userID
             val intent = Intent(this, ListActivity::class.java)
             intent.putExtra("userID", userId)
             apkPathResult.launch(intent)
@@ -142,7 +142,12 @@ class MainActivity : LoadingActivity() {
                     val userId = data.getIntExtra("userID", 0)
                     val source = data.getStringExtra("source")
                     if (source != null) {
-                        fragmentList[userId].installApk(source)
+                        val fragment = fragmentList.firstOrNull { it.userID == userId }
+                        if (fragment != null) {
+                            fragment.installApk(source)
+                        } else {
+                            ToastUtils.showToast("User $userId not found")
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary
- ensure the floating action button launches the install flow for the currently selected fragment user ID
- update the install result handling to find fragments by user ID and show a toast when missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0ed4b57388325a396cd8db7dde746