### PR TITLE
Document Android SDK prerequisites for build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,26 @@ wrapper. The helper script below pins the Java toolchain to JDK 17 so
 that the legacy Android Gradle Plugin used by this project runs
 successfully.
 
-1. Ensure you have internet connectivity the first time you build so
+1. Configure the Android SDK location before running the build. Either
+   export the `ANDROID_SDK_ROOT` environment variable or create a
+   `local.properties` file containing `sdk.dir=/absolute/path/to/sdk`.
+   Without one of these options Gradle cannot locate the SDK and the
+   build script will exit with an error. See below for an example:
+
+   ```bash
+   echo "sdk.dir=$HOME/Android/Sdk" > local.properties
+   ```
+
+2. Ensure you have internet connectivity the first time you build so
    Gradle can download the Android Gradle Plugin and Kotlin compiler
    dependencies.
-2. From the repository root execute:
+3. From the repository root execute:
 
    ```bash
    ./build_apk.sh
    ```
 
-3. After a successful build the APK is generated at
+4. After a successful build the APK is generated at
    `app/build/outputs/apk/debug/app-debug.apk`.
 
 > **Note:** The build will fail in fully offline environments because

--- a/build_apk.sh
+++ b/build_apk.sh
@@ -8,5 +8,20 @@ if [ -d "$JAVA_HOME_DEFAULT" ]; then
   export PATH="$JAVA_HOME/bin:$PATH"
 fi
 
+sdk_path=""
+
+if [ -n "${ANDROID_SDK_ROOT:-}" ]; then
+  sdk_path="$ANDROID_SDK_ROOT"
+elif [ -f "local.properties" ]; then
+  sdk_path=$(awk -F '=' '/^sdk.dir[[:space:]]*=/ {sub(/^\s*/, "", $2); print $2; exit}' local.properties | tr -d '\r')
+fi
+
+if [ -z "$sdk_path" ] || [ ! -d "$sdk_path" ]; then
+  cat >&2 <<'EOF'
+Error: Android SDK not found. Set ANDROID_SDK_ROOT or create local.properties with sdk.dir=<absolute path> before running ./build_apk.sh. See the "Building the APK" section in README.md for details.
+EOF
+  exit 1
+fi
+
 echo "Using JAVA_HOME=$JAVA_HOME"
 ./gradlew assembleDebug "$@"


### PR DESCRIPTION
## Summary
- document how to configure the Android SDK path before running the APK build helper
- add validation in build_apk.sh to stop early with a clear SDK configuration error message

## Testing
- bash -n build_apk.sh

------
https://chatgpt.com/codex/tasks/task_e_68e0ef5d8fac8325a48abcd37b4cb337