### PR TITLE
Fix HackApplication initialization check

### DIFF
--- a/hack/src/main/java/com/hack/opensdk/HackApi.kt
+++ b/hack/src/main/java/com/hack/opensdk/HackApi.kt
@@ -11,7 +11,7 @@ object HackApi {
 
     private val application: Application
         get() {
-            if (!::HackApplication.application.isInitialized) {
+            if (!HackApplication::application.isInitialized) {
                 throw IllegalStateException("HackApplication is not initialized")
             }
             return HackApplication.application


### PR DESCRIPTION
## Summary
- correct the HackApplication initialization check in HackApi to use the proper property reference

## Testing
- `./gradlew :hack:compileDebugKotlin` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68e0fe51385483258f4fea6567ffa798