### PR TITLE
Ensure HackApi accesses application instance safely

### DIFF
--- a/hack/src/main/java/com/hack/opensdk/HackApi.kt
+++ b/hack/src/main/java/com/hack/opensdk/HackApi.kt
@@ -11,10 +11,11 @@ object HackApi {
 
     private val application: Application
         get() {
-            if (!HackApplication::application.isInitialized) {
+            try {
+                return HackApplication.getInstance()
+            } catch (_: UninitializedPropertyAccessException) {
                 throw IllegalStateException("HackApplication is not initialized")
             }
-            return HackApplication.application
         }
 
     private val packageManager: PackageManager


### PR DESCRIPTION
## Summary
- replace reflection-based initialization check with try/catch around HackApplication.getInstance
- continue to surface an IllegalStateException when HackApplication has not been initialized

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0ff600f2c8325b804ff855f7b2ca5