### PR TITLE
Guard VM install list against null package info

### DIFF
--- a/app/src/main/java/virtual/camera/app/data/AppsRepository.kt
+++ b/app/src/main/java/virtual/camera/app/data/AppsRepository.kt
@@ -119,8 +119,10 @@ class AppsRepository {
 
         var applicationList = mutableListOf<ApplicationInfo>()
         installedPkgs.forEach {
-            var packageInfo = HackApi.getPackageInfo(it, userId, 0)
-            applicationList.add(packageInfo.applicationInfo)
+            val packageInfo = HackApi.getPackageInfo(it, userId, 0)
+            packageInfo?.applicationInfo?.let { applicationInfo ->
+                applicationList.add(applicationInfo)
+            }
         }
 
         val appInfoList = mutableListOf<AppInfo>()


### PR DESCRIPTION
## Summary
- guard the VM install list population against null package info results from HackApi

## Testing
- ./gradlew :app:assembleDebug *(fails: proxy prevented Gradle download)*

------
https://chatgpt.com/codex/tasks/task_e_68e1004d31948325b27992c5c6858656