### PR TITLE
Add SharedPreferences-backed MultiPreferences replacement

### DIFF
--- a/app/src/main/java/virtual/camera/app/settings/MultiPreferences.java
+++ b/app/src/main/java/virtual/camera/app/settings/MultiPreferences.java
@@ -1,0 +1,74 @@
+package virtual.camera.app.settings;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.annotation.Nullable;
+
+import virtual.camera.app.app.App;
+
+/**
+ * A minimal in-project replacement for the removed MultiPreferences helper.
+ * Provides a singleton access point backed by SharedPreferences.
+ */
+public final class MultiPreferences {
+    private static final String PREFERENCES_NAME = "virtual_camera_preferences";
+    private static volatile MultiPreferences sInstance;
+
+    private final SharedPreferences sharedPreferences;
+
+    private MultiPreferences(Context context) {
+        sharedPreferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
+    }
+
+    public static MultiPreferences getInstance() {
+        if (sInstance == null) {
+            synchronized (MultiPreferences.class) {
+                if (sInstance == null) {
+                    sInstance = new MultiPreferences(App.getContext());
+                }
+            }
+        }
+        return sInstance;
+    }
+
+    public int getInt(String key, int defaultValue) {
+        return sharedPreferences.getInt(key, defaultValue);
+    }
+
+    public void setInt(String key, int value) {
+        sharedPreferences.edit().putInt(key, value).apply();
+    }
+
+    public long getLong(String key, long defaultValue) {
+        return sharedPreferences.getLong(key, defaultValue);
+    }
+
+    public void setLong(String key, long value) {
+        sharedPreferences.edit().putLong(key, value).apply();
+    }
+
+    public String getString(String key, @Nullable String defaultValue) {
+        return sharedPreferences.getString(key, defaultValue);
+    }
+
+    public void setString(String key, @Nullable String value) {
+        sharedPreferences.edit().putString(key, value).apply();
+    }
+
+    public boolean getBoolean(String key, boolean defaultValue) {
+        return sharedPreferences.getBoolean(key, defaultValue);
+    }
+
+    public void setBoolean(String key, boolean value) {
+        sharedPreferences.edit().putBoolean(key, value).apply();
+    }
+
+    public void remove(String key) {
+        sharedPreferences.edit().remove(key).apply();
+    }
+
+    public void clear() {
+        sharedPreferences.edit().clear().apply();
+    }
+}

--- a/app/src/main/java/virtual/camera/app/view/main/DialogUtil.java
+++ b/app/src/main/java/virtual/camera/app/view/main/DialogUtil.java
@@ -9,7 +9,7 @@ import androidx.appcompat.app.AlertDialog;
 
 import virtual.camera.app.R;
 import virtual.camera.app.util.ToastUtils;
-import virtual.camera.camera.MultiPreferences;
+import virtual.camera.app.settings.MultiPreferences;
 
 public class DialogUtil {
     public static void showDialog(final Activity activity, boolean check) {

--- a/app/src/main/java/virtual/camera/app/view/setting/SettingFragment.java
+++ b/app/src/main/java/virtual/camera/app/view/setting/SettingFragment.java
@@ -27,7 +27,7 @@ import virtual.camera.app.R;
 import virtual.camera.app.app.App;
 import virtual.camera.app.settings.LogUtil;
 import virtual.camera.app.settings.MethodType;
-import virtual.camera.camera.MultiPreferences;
+import virtual.camera.app.settings.MultiPreferences;
 import virtual.camera.app.util.AppUtil;
 import virtual.camera.app.util.HandlerUtil;
 import virtual.camera.app.util.ToastUtils;


### PR DESCRIPTION
## Summary
- add a SharedPreferences-backed MultiPreferences helper inside the project
- update SettingFragment and DialogUtil to use the in-project replacement

## Testing
- ./gradlew assembleDebug *(fails: Unable to download Gradle distribution because of proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e10262a7e08325b6a46977d0251e6a